### PR TITLE
Fix: Added leading zeros for timer display

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,23 @@
 "use strict";
 import "./style.css";
 
+// Süreler buradan ayarlanır.
+let min: number = 24;
+let sec: number = 0o0;
+
 class Timer {
     constructor(public min: number, public sec: number) {
         this.doTimer().then();
     }
 
     async doTimer(): Promise<void> {
-        let min: number; min = this.min;
-        let sec: number; sec = this.sec;
+        let min: number = this.min;
+        let sec: number = this.sec;
+
         while (min >= 0) {
             this.updateCounter(min, sec);
             await delay(1000); // 1 saniye
-            sec -=1;
+            sec -= 1;
             if (sec === -1) {
                 min -= 1;
                 sec = 59;
@@ -26,21 +31,17 @@ class Timer {
         this.updateCounter(min, sec);
     }
 
-    updateCounter (min:number, sec: number): void {
-        const timerElement:HTMLElement = document.getElementById("timer") as HTMLElement;
+    updateCounter(min: number, sec: number): void {
+        const timerElement: HTMLElement = document.getElementById("timer") as HTMLElement;
         if (timerElement) {
             if (min === 0 && sec === 0) {
                 timerElement.innerText = "Süre bitti";
-                document.getElementById("startButton")!.removeAttribute('disabled');
-            } else if (sec < 10) {
-                timerElement.innerText = `${min} : 0${sec}`;
-                if (min < 10) {
-                    timerElement.innerText = `0${min} : 0${sec}`;
-                }
-            } else if (min < 10) {
-                timerElement.innerText = `0${min} : ${sec}`;
+                document.getElementById("startButton")!.removeAttribute("disabled");
             } else {
-                timerElement.innerText = `${min} : ${sec}`;
+                // Dakika ve saniyeyi iki basamaklı formatta göster
+                const formattedMin: string = min.toString().padStart(2, "0");
+                const formattedSec: string = sec.toString().padStart(2, "0");
+                timerElement.innerText = `${formattedMin} : ${formattedSec}`;
             }
         }
     }
@@ -50,15 +51,10 @@ function delay(delay: number): Promise<void> {
     return new Promise((resolve: (value: (PromiseLike<void> | void)) => void): number => setTimeout(resolve, delay));
 }
 
-// süreler buradan ayarlarnır.
-let min: number = 24;
-let sec: number = 0;
-
-
 document.querySelector<HTMLDivElement>(`#app`)!.innerHTML = `
  <h1> Pomodoro App </h1>
- <p id="timer">${min} : ${sec}</p>
- <button id="startButton" > Start </button>
+ <p id="timer">${min.toString().padStart(2, "0")} : ${sec.toString().padStart(2, "0")}</p>
+ <button id="startButton"> Start </button>
 `;
 
 document.getElementById("startButton")!.addEventListener("click", (): void => {


### PR DESCRIPTION
This PR fixes the issue of missing leading zeros in the timer display.
Resolved Issue: #1 
Changes:
- Added `padStart` to ensure two-digit formatting for minutes and seconds.
